### PR TITLE
show fallback when endcard container shown before api answer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0",
+  "version": "1.1.1",
   "name": "@stroeer/stroeer-videoplayer-plugin-endcard",
   "description": "Ströer Videoplayer Endcard Plugin",
   "main": "dist/stroeerVideoplayer-endcard-plugin.umd.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,6 @@ const onVideoElEnd = (e: Event): void => {
   if (e.target !== null) e.target.addEventListener('play', onVideoElPlay)
   endcardPlugin.addClickEvents()
   endcardPlugin.show()
-  endcardPlugin.revolverplay()
 }
 
 const plugin = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,6 @@ const onVideoElFirstQuartile = (): void => {
 
 const onVideoElEnd = (e: Event): void => {
   if (e.target !== null) e.target.addEventListener('play', onVideoElPlay)
-  endcardPlugin.addClickEvents()
   endcardPlugin.show()
 }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -233,12 +233,14 @@ class EndcardPlugin {
       this.renderFallback()
       return
     }
-
     fetchAPI<object>(endpoint)
       .then((data) => {
         this.transformedData = transformData(data, this.dataKeyMap)
         this.transformedData = this.transformApiData(this.transformedData)
         logger.log(this.transformedData)
+
+        this.showFallback = false
+        this.endcardContainer.innerHTML = ''
 
         for (let i: number = 0; i < 5; i++) {
           const tileTemplate = getTile(
@@ -254,6 +256,7 @@ class EndcardPlugin {
           }
           this.endcardContainer.innerHTML += tileTemplate
         }
+        this.revolverplay()
       })
       .catch((err) => {
         logger.log('Something went wrong with fetching api!', err)
@@ -274,6 +277,10 @@ class EndcardPlugin {
 
     if (typeof this.videoplayer.exitFullscreen === 'function') {
       this.videoplayer.exitFullscreen()
+    }
+    if (this.endcardContainer.childNodes.length === 0) {
+      this.showFallback = true
+      this.renderFallback()
     }
     this.endcardContainer.classList.remove('endcard-hidden')
     this.dispatchEvent('plugin-endcard:show')

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -17,6 +17,7 @@ class EndcardPlugin {
   dataKeyMap: object
   transformedData: IData[]
   showFallback: boolean
+  isVideoFinished: boolean
   uiEl: HTMLDivElement
   revolverplayTime: number
   intervalTicker: NodeJS.Timeout | null
@@ -59,6 +60,7 @@ class EndcardPlugin {
     this.transformApiData =
       opts.transformApiData !== undefined ? opts.transformApiData : noopData
 
+    this.isVideoFinished = false
     this.uiEl = stroeervideoplayer.getUIEl()
 
     this.endcardContainer = document.createElement('div')
@@ -90,6 +92,7 @@ class EndcardPlugin {
     this.removeClickEvents()
     this.endcardContainer.innerHTML = ''
     this.hide()
+    this.isVideoFinished = false
   }
 
   revolverplay = (): void => {
@@ -224,6 +227,7 @@ class EndcardPlugin {
       'plugin-endcard-tile-single'
     )
     this.endcardContainer.innerHTML += replayTemplate
+    this.addClickEvents()
   }
 
   render = (): void => {
@@ -257,7 +261,8 @@ class EndcardPlugin {
           }
           this.endcardContainer.innerHTML += tileTemplate
         }
-        if(!this.endcardContainer.classList.contains('endcard-hidden')) {
+        this.addClickEvents()
+        if (this.isVideoFinished) {
           this.revolverplay()
         } 
       })
@@ -277,6 +282,7 @@ class EndcardPlugin {
 
   show = (): void => {
     this.uiEl.classList.add('plugin-endcard-ui-small')
+    this.isVideoFinished = true
 
     if (typeof this.videoplayer.exitFullscreen === 'function') {
       this.videoplayer.exitFullscreen()

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -233,6 +233,7 @@ class EndcardPlugin {
       this.renderFallback()
       return
     }
+
     fetchAPI<object>(endpoint)
       .then((data) => {
         this.transformedData = transformData(data, this.dataKeyMap)
@@ -256,7 +257,9 @@ class EndcardPlugin {
           }
           this.endcardContainer.innerHTML += tileTemplate
         }
-        this.revolverplay()
+        if(!this.endcardContainer.classList.contains('endcard-hidden')) {
+          this.revolverplay()
+        } 
       })
       .catch((err) => {
         logger.log('Something went wrong with fetching api!', err)
@@ -281,6 +284,8 @@ class EndcardPlugin {
     if (this.endcardContainer.childNodes.length === 0) {
       this.showFallback = true
       this.renderFallback()
+    } else {
+      this.revolverplay()
     }
     this.endcardContainer.classList.remove('endcard-hidden')
     this.dispatchEvent('plugin-endcard:show')

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -245,3 +245,19 @@ describe('testing render with failing fetch API', () => {
     expect(plugin.renderFallback).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('testing render with pending fetch api', () => {
+  let container: any
+  beforeEach(() => {
+      container = plugin.endcardContainer.innerHTML;
+  })
+  afterEach(() => {
+      plugin.endcardContainer.innerHTML = container;
+  })
+  test('show should call fallback when endcard div is empty', () => {
+      plugin.renderFallback = jest.fn()
+      plugin.endcardContainer.innerHTML = ''
+      plugin.show()
+      expect(plugin.renderFallback).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
fix for edge case: if the api answers after the endcard container is already shown, we would see nothing and therefore show the fallback and replace it as soon as the api answers and show the suggested videos as normal.

can be tested by a timeout on the fetch oder throttling in the network (I guess)