### PR TITLE
fix for multiple players with endcard plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.1",
+  "version": "1.1.2",
   "name": "@stroeer/stroeer-videoplayer-plugin-endcard",
   "description": "Ströer Videoplayer Endcard Plugin",
   "main": "dist/stroeerVideoplayer-endcard-plugin.umd.js",


### PR DESCRIPTION
If you had 2 players on one page, the endcard plugin did not work completely isolated for each player and was buggy.
It just needed to take the event listener into the instance of the endcard plugin and now it works as it should ;)

(deinit not needed right now, plays endlessly and will be implemented later)