### PR TITLE
show maximum 2 lines of video title

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.2",
+  "version": "1.1.3",
   "name": "@stroeer/stroeer-videoplayer-plugin-endcard",
   "description": "Ströer Videoplayer Endcard Plugin",
   "main": "dist/stroeerVideoplayer-endcard-plugin.umd.js",

--- a/src/endcard.scss
+++ b/src/endcard.scss
@@ -107,6 +107,13 @@ $endcard-plugin-controlbar-height-mobile: 55px !default;
   font-size: $endcard-plugin-font-size-medium;
 }
 
+.plugin-endcard-title-main {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
 .plugin-endcard-title {
   margin: 0;
   padding: $endcard-plugin-spacing-small;

--- a/src/template.ts
+++ b/src/template.ts
@@ -50,7 +50,7 @@ const getTile = (index: number, obj: IData, revolverplayTime: number): string =>
         `}
         <p class="plugin-endcard-title">
           ${index === 0 ? '<span class="plugin-endcard-title-pre">Nächstes Video</span>' : ''}
-          ${obj.title}
+          <span class="plugin-endcard-title-main">${obj.title}</span>
         </p>
       </div>
     </div>

--- a/tests/__snapshots__/template.test.ts.snap
+++ b/tests/__snapshots__/template.test.ts.snap
@@ -231,7 +231,13 @@ exports[`Tile markup is rendered as expected when revolverplay is active 1`] = `
           Nächstes Video
         </span>
         
+          
+        <span
+          class="plugin-endcard-title-main"
+        >
           Bei voller Fahrt kommt plötzlich Panik auf
+        </span>
+        
         
       </p>
       
@@ -303,7 +309,13 @@ exports[`Tile markup is rendered as expected when revolverplay is active 1`] = `
       >
         
           
+          
+        <span
+          class="plugin-endcard-title-main"
+        >
           Bei voller Fahrt kommt plötzlich Panik auf
+        </span>
+        
         
       </p>
       
@@ -375,7 +387,13 @@ exports[`Tile markup is rendered as expected when revolverplay is active 1`] = `
       >
         
           
+          
+        <span
+          class="plugin-endcard-title-main"
+        >
           Bei voller Fahrt kommt plötzlich Panik auf
+        </span>
+        
         
       </p>
       
@@ -447,7 +465,13 @@ exports[`Tile markup is rendered as expected when revolverplay is active 1`] = `
       >
         
           
+          
+        <span
+          class="plugin-endcard-title-main"
+        >
           Bei voller Fahrt kommt plötzlich Panik auf
+        </span>
+        
         
       </p>
       
@@ -519,7 +543,13 @@ exports[`Tile markup is rendered as expected when revolverplay is active 1`] = `
       >
         
           
+          
+        <span
+          class="plugin-endcard-title-main"
+        >
           Bei voller Fahrt kommt plötzlich Panik auf
+        </span>
+        
         
       </p>
       
@@ -673,7 +703,13 @@ exports[`Tile markup is rendered as expected when revolverplay is not active 1`]
           Nächstes Video
         </span>
         
+          
+        <span
+          class="plugin-endcard-title-main"
+        >
           Bei voller Fahrt kommt plötzlich Panik auf
+        </span>
+        
         
       </p>
       
@@ -745,7 +781,13 @@ exports[`Tile markup is rendered as expected when revolverplay is not active 1`]
       >
         
           
+          
+        <span
+          class="plugin-endcard-title-main"
+        >
           Bei voller Fahrt kommt plötzlich Panik auf
+        </span>
+        
         
       </p>
       
@@ -817,7 +859,13 @@ exports[`Tile markup is rendered as expected when revolverplay is not active 1`]
       >
         
           
+          
+        <span
+          class="plugin-endcard-title-main"
+        >
           Bei voller Fahrt kommt plötzlich Panik auf
+        </span>
+        
         
       </p>
       
@@ -889,7 +937,13 @@ exports[`Tile markup is rendered as expected when revolverplay is not active 1`]
       >
         
           
+          
+        <span
+          class="plugin-endcard-title-main"
+        >
           Bei voller Fahrt kommt plötzlich Panik auf
+        </span>
+        
         
       </p>
       
@@ -961,7 +1015,13 @@ exports[`Tile markup is rendered as expected when revolverplay is not active 1`]
       >
         
           
+          
+        <span
+          class="plugin-endcard-title-main"
+        >
           Bei voller Fahrt kommt plötzlich Panik auf
+        </span>
+        
         
       </p>
       


### PR DESCRIPTION
For all tiles except the replay tile, we will shorten the title to maximum 2 lines and add ellipsis. we can use webkit-line-clamp, because it is supported by all browsers of our browsers list.