### PR TITLE
correct to new plugin name (lowercase only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The Stroeer Videoplayer Endcard Plugin works with data from a custom API but use
 The Stroeer Videoplayer Endcard Plugin uses determined [data keys](https://github.com/stroeer/stroeer-videoplayer-plugin-endcard/blob/main/types/types.d.ts#L1). If these keys are named different in your API, you can map as many keys as you like via `dataKeyMap` in options object.
 
 ```javascript
-myvideoplayer.initPlugin('Endcard', {
+myvideoplayer.initPlugin('endcard', {
   showEndcard: true,
 	dataKeyMap: {
 		// key of endcard, key from API
@@ -156,7 +156,7 @@ The only required data-attribute for the endcard to work is `data-endcard-url`.
 
 ```javascript
 const myvideoplayer = new StroeerVideoplayer(video)
-myvideoplayer.initPlugin('Endcard', {
+myvideoplayer.initPlugin('endcard', {
 	revolverplayTime: 7,
 	dataKeyMap: {
 		image_large: 'preview_image',

--- a/dev/dev.js
+++ b/dev/dev.js
@@ -39,7 +39,7 @@ video.addEventListener('contentVideoStart', function () {
   console.log('playRound: ', playRound)
   if (playRound === 3) {
     console.log('DEINIT')
-    myvideoplayer.deinitPlugin('Endcard')
+    myvideoplayer.deinitPlugin('endcard')
   }
 })
 
@@ -83,7 +83,7 @@ const myvideoplayer = new StroeerVideoplayer(video)
 myvideoplayer.loadStreamSource()
 myvideoplayer.loadFirstChunk()
 
-myvideoplayer.initPlugin('Endcard', {
+myvideoplayer.initPlugin('endcard', {
   revolverplayTime: 7,
   dataKeyMap: {
     // key of endcard, key from API

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "2.0.1",
   "name": "@stroeer/stroeer-videoplayer-plugin-endcard",
   "description": "Ströer Videoplayer Endcard Plugin",
   "main": "dist/stroeerVideoplayer-endcard-plugin.umd.js",


### PR DESCRIPTION
just corrected the plugin name in the examples